### PR TITLE
11 calculate all knockout stage matches

### DIFF
--- a/docs/knockouts.md
+++ b/docs/knockouts.md
@@ -12,6 +12,69 @@ for the top 2 teams in a competition with 2 groups. The number of teams in the
 knockout stage is determined by the number of teams in the competition and the
 rules defined in the brackets section of the tournament. 
 
+## Bracket rules
+
+Generally speaking, based on seeding, and on-average, larger group sizes, the
+lower number group should be most difficult and highest number group least
+difficult. Given the following final group standings for a competion:
+
+    | POS | GROUP 1 | GROUP 2 | GROUP 3 | GROUP 4 |
+    |-----|---------|---------|---------|---------|
+    | 1   | Team 1  | Team 2  | Team 3  | Team 4  |
+    | 2   | Team 5  | Team 6  | Team 7  | Team 8  |
+    | ... | ...     | ...     | ...     | ...     |
+    | 3   | Team 9  | Team 10 | Team 11 | Team 12 |
+
+... a 4-team bracket will look like this:
+
+      Team 1 -+
+              |
+              +-> ? -+
+              |      |
+      Team 3 -+      |
+                     +-> ? Winner
+                     |
+      Team 2 -+      |
+              |      |
+              +-> ? -+
+              |      
+      Team 4 -+
+
+... and an 8-team bracket will look like this:
+
+      Team 1 -+
+              |
+              +-> ? -+
+              |      |
+      Team 8 -+      |
+                     +-> ? -+
+                     |      |
+      Team 3 -+      |      |
+              |      |      |
+              +-> ? -+      |
+              |             |
+      Team 6 -+             |
+                            +-> ? Winner
+      Team 2 -+             |
+              |             |
+              +-> ? -+      |
+              |      |      |
+      Team 7 -+      |      |
+                     +-> ? -+
+                     |
+      Team 4 -+      |
+              |      |
+              +-> ? -+
+              |
+      Team 5 -+
+
+If there are fewer than 8 teams to fill the bracket, the teams from the toughest
+groups will benefit by automatically advancing to the next round. More than 8
+teams is not possible since this will lead to a new bracket (e.g. "spoon").
+
+The above rules work well for power of 2 numbers of teams and lead to very clear
+rules. This is so simple it can even be hard-coded.
+
 ## Examples
 
 Given a definition as follows:
@@ -31,7 +94,7 @@ the final if possible. Using the default rules, the number of teams will be a
 power of 2 and all but the last division must choose a power of 2 number of
 teams. The last division will take the remaining teams.
 
-### Example 1
+### Example 1: 4 groups of 3/4 teams
 
 Give the following group result for a 13 team competitions:
 
@@ -59,3 +122,103 @@ order will be randomly determined and the decision to do so will be logged for
 audit purposes. 
 
 
+In the above example, the knockout table should look as follows:
+
+    CUP:
+
+      Team 3 -+
+              |
+              +-> ? -+
+              |      |
+      Team 9 -+      |
+                     +-> ? Winner
+                     |
+      Team 6 -+      |
+              |      |
+              +-> ? -+
+              |
+     Team 11 -+
+
+
+    PLATE:
+
+      Team 1 -+
+              |
+              +-> ? -+
+              |      |
+      Team 5 -+      |
+                     +-> ? Winner
+                     |
+     Team 10 -+      |
+              |      |
+              +-> ? -+
+              |
+     Team 13 -+
+
+
+    BOWL:
+
+             Team 4 -+
+                     |
+                     +-> ? -+
+                     |      |
+             Team 7 -+      |
+                            +-> ? Winner
+                            |
+             Team 8 -+      |
+                     |      |
+                     +-> ? -+
+                     |
+     Team 10 -+      |
+              |      |
+              +-> ? -+
+              |
+     Team 13 -+
+
+# Example 2: 2 groups of 5/4 teams
+
+Given the following group result for a 9 team competition:
+
+| POS | GROUP 1 | GROUP 2 |
+|-----|---------|---------|
+| 1   | Team 2  | Team 8  |
+| 2   | Team 5  | Team 7  |
+| 3   | Team 1  | Team 6  |
+| 4   | Team 4  | Team 9  |
+| 5   | Team 3  |         |
+
+Applying similar logic as in the previous example, the knockout table should look as follows:
+
+    CUP:
+
+      Team 2 -+
+              |
+              +-> ? -+
+              |      |
+      Team 8 -+      |
+                     +-> ? Winner
+                     |
+      Team 5 -+      |
+              |      |
+              +-> ? -+
+              |
+      Team 7 -+
+
+    PLATE:
+
+             Team 4 -+
+                     |
+                     +-> ? -+
+                     |      |
+             Team 7 -+      |
+                            +-> ? Winner
+                            |
+             Team 8 -+      |
+                     |      |
+                     +-> ? -+
+                     |
+     Team 10 -+      |
+              |      |
+              +-> ? -+
+              |
+     Team 13 -+

--- a/src/Tournament.class.js
+++ b/src/Tournament.class.js
@@ -88,6 +88,31 @@ class Tournament {
     this.categories = categories;
     this.fixtures = fixtures;
   }
+  // OUTPUT
+  prettyPrintFixtures(filters = {}) {
+    console.table(this.fixtures
+      .filter(f => {
+        if (filters.category) {
+          return f.category === filters.category
+        }
+        return true
+      })
+      .map(m => {
+        const strteam = t => {
+          const { type, stage, group, position } = t;
+          if (type === 'calculated') {
+            return `~${stage}:${group}/p:${position}`
+          } else {
+            return t
+          }
+        }
+        return {
+          ...m,
+          team1: strteam(m.team1),
+          team2: strteam(m.team2),
+        }
+      }))
+  }
   // ASSERTIONS
   assertCategory(cat) {
     const names = this.categoryNames;

--- a/src/TournamentOrganize.spec.js
+++ b/src/TournamentOrganize.spec.js
@@ -1,4 +1,5 @@
 const TEST_DATA = require('../test/test-data');
+const { prettyPrintMatches } = require("../test/test-util");
 const Tournament = require('./Tournament.class')
 const TournamentOrganize = require('./TournamentOrganize.class');
 
@@ -10,18 +11,24 @@ describe('TournamentOrganize', () => {
     const cat = 'Mens'
     const T = new Tournament(tournament_1)
     const TO = new TournamentOrganize(T)
-    expect(T.categories[cat].groups).toBeFalsy()
+    expect(T.categories[cat].groups.length).toBe(0)
     TO.assignTeamsToGroups(cat)
     expect(T.categories[cat].groups).not.toBeFalsy()
   })
 
-
+  it("generates fixtures for all knockout stages", () => {
+    const T = new Tournament(tournament_1)
+    const TO = new TournamentOrganize(T)
+    const matches = TO.generateKnockoutFixtures()
+    prettyPrintMatches(matches);
+    expect(T.fixtures.length).toBeGreaterThan(0)
+  })
 
 })
 
 describe('End to end tournament organization', () => {
 
-  it('completes the definition of a tournament from a minimal rules input', () => {
+  it.only('completes the definition of a tournament from a minimal rules input', () => {
     const T = new Tournament(tournament_1);
     const TO = new TournamentOrganize(T);
     TO.generate();

--- a/src/util.js
+++ b/src/util.js
@@ -187,13 +187,13 @@ const calculateKnockoutStageFixtures = (
           team2: calcType('group', 4, 1), // "~group:4/p:1", // "Winner of Group 4"
         },
         {
-          stage: 'bronze',
+          stage: 'bronze:1',
           allottedTime: slackLookup.bronze,
           team1: calcType('semis', 1, 2),
           team2: calcType('semis', 2, 2),
         },
         {
-          stage: 'finals',
+          stage: 'finals:1',
           allottedTime: slackLookup.finals,
           team1: calcType('semis', 1, 1),
           team2: calcType('semis', 2, 1),
@@ -209,7 +209,6 @@ const calculateKnockoutStageFixtures = (
           case 'quarters':
             if (teamIds.includes(team1) && teamIds.includes(team2)) {
               return {
-                id,
                 stage,
                 allottedTime: slackLookup[progression],
                 team1: calcType('group', team1, 1), 
@@ -221,7 +220,6 @@ const calculateKnockoutStageFixtures = (
             break
           case 'semis':
             return {
-              id,
               stage,
               allottedTime: slackLookup[progression],
               // some teams may automatically qualify
@@ -235,7 +233,6 @@ const calculateKnockoutStageFixtures = (
             break
           case 'bronze':
             return {
-              id,
               stage,
               allottedTime: slackLookup[progression],
               team1: calcType('semis', team1, 2), // `~semis:${team1}/p:2`,
@@ -244,7 +241,6 @@ const calculateKnockoutStageFixtures = (
             break
           case 'finals':
             return {
-              id,
               stage,
               allottedTime: slackLookup[progression],
               team1: calcType('semis', team1, 1), // `~semis:${team1}/p:1`,
@@ -271,7 +267,12 @@ const calculateKnockoutStageFixtures = (
         ), // quarters 3 vs 4
         addMatch(7, 'bronze:1', 1, 2), // semis 1 vs 2
         addMatch(8, 'finals:1', 1, 2), // semis 3 vs 4
-      ].filter(x => !x.autoqual)
+      ].filter(x => !x.autoqual).map(x => {
+        return {
+          ...x,
+          groupSize: numTeams
+        }
+      })
       break;
   }
   return matches;

--- a/src/util.spec.js
+++ b/src/util.spec.js
@@ -1,8 +1,12 @@
 const { 
   calculateNextGameStartTime, 
   calculateGroupStageFixtures,
+  calculateKnockoutStageFixtures,
+  getTeamIds,
   assignTeamsToGroups 
 } = require("./util");
+
+const VERBOSE = false;
 
 describe("Useful utility functions", () => {
   it("can calculate time for upcoming matches", () => {
@@ -46,7 +50,7 @@ describe("Useful utility functions", () => {
   });
 
 
-  it.only('maximizes rest time for teams in stage', () => {
+  it('maximizes rest time for teams in stage', () => {
     const slack = [0, 0, 60, 40, 25, 20, 15];
     const groups = [
       ['Team 1', 'Team 2', 'Team 3', 'Team 4', 'Team 11'],
@@ -54,7 +58,7 @@ describe("Useful utility functions", () => {
       ['Team 8', 'Team 9', 'Team 10'],
     ]
     const matches = calculateGroupStageFixtures('Mens', groups, slack, false);
-    console.table(matches.filter(m => m.group === 0))
+    // console.table(matches.filter(m => m.group === 0))
     matches.forEach(match => {
       expect(match.allottedTime).toBeGreaterThanOrEqual(0)
     })
@@ -77,4 +81,115 @@ describe("Useful utility functions", () => {
       (1 + 2)       // A group of 3
     );
   })
+
 });
+
+describe("Knockout stage fixtures", () => {
+  it('Can work out team ids based on list', () => {
+    let ids = []
+    ids = getTeamIds([0, 3], [4, 3, 3, 3])
+    expect(ids).toEqual([1, 2, 3, 4])
+    ids = getTeamIds([8, 15], [5, 3, 3, 3])
+    expect(ids).toEqual([1, 2, 3, 4, 5, 6])
+    ids = getTeamIds([4, 15], [6, 5])
+    expect(ids).toEqual([1, 2, 3, 4, 5, 6, 7])
+  })
+
+  it('schedules knockout fixtures for a 4-team bracket', () => {
+    const range = [0, 3];
+    const groupSizes = [4, 3, 3, 3];
+    const slack = [25, 30, 35, 40];
+    const matches = calculateKnockoutStageFixtures(
+      range,
+      groupSizes,
+      slack
+    );
+    prettyPrintMatches(matches);
+    expect(matches.length).toBe(4)
+    expect(matches[0].stage).toBe('semis:1')
+    expect(matches.filter(m => m.stage === 'finals:1').shift().allottedTime).toBe(slack.pop())
+  })
+  it('schedules knockout fixtures for a 8-team bracket with fewer than 8 teams', () => {
+    // With all 8 teams in the last bracket
+    {
+      const range = [8, 15];
+      const groupSizes = [4, 4, 4, 4];
+      const slack = [25, 30, 35, 40];
+      const matches = calculateKnockoutStageFixtures(
+        range,
+        groupSizes,
+        slack
+      );
+      prettyPrintMatches(matches)
+      expect(matches.length).toBe(8)
+      const quarters = matches.filter(m => m.stage.startsWith('quarters'))
+      expect(quarters.length).toBe(4)
+      const semis = matches.filter(m => m.stage.startsWith('semis'))
+      expect(semis.length).toBe(2)
+      const firstSemis = matches.filter(m => m.stage === 'semis:1').shift()
+      expect(firstSemis.team1.stage).toBe('quarters')
+      expect(firstSemis.team2.stage).toBe('quarters')
+    }
+    // With 6 teams in the last bracket
+    {
+      const range = [8, 15];
+      const groupSizes = [4, 4, 3, 3];
+      const slack = [25, 30, 35, 40];
+      const matches = calculateKnockoutStageFixtures(
+        range,
+        groupSizes,
+        slack
+      );
+      prettyPrintMatches(matches)
+      expect(matches.length).toBe(6)
+      const quarters = matches.filter(m => m.stage.startsWith('quarters'))
+      expect(quarters.length).toBe(2)
+      const semis = matches.filter(m => m.stage.startsWith('semis'))
+      expect(semis.length).toBe(2)
+      const firstSemis = matches.filter(m => m.stage === 'semis:1').shift()
+      expect(firstSemis.team1.stage).toBe('group')
+      expect(firstSemis.team2.stage).toBe('quarters')
+    }
+    // With 4 teams in the last bracket
+    {
+      const range = [8, 15];
+      const groupSizes = [3, 3, 3, 3];
+      const slack = [25, 30, 35, 40];
+      const matches = calculateKnockoutStageFixtures(
+        range,
+        groupSizes,
+        slack
+      );
+      prettyPrintMatches(matches)
+      expect(matches.length).toBe(4)
+      const quarters = matches.filter(m => m.stage.startsWith('quarters'))
+      expect(quarters.length).toBe(0)
+      const semis = matches.filter(m => m.stage.startsWith('semis'))
+      expect(semis.length).toBe(2)
+      const firstSemis = matches.filter(m => m.stage === 'semis:1').shift()
+      expect(firstSemis.team1.stage).toBe('group')
+      expect(firstSemis.team2.stage).toBe('group')
+    }
+  })
+})
+
+
+function prettyPrintMatches(matches) {
+  return VERBOSE
+    ? console.table(matches.map(m => {
+      const strteam = t => {
+        const { type, stage, group, position } = t;
+        if (type === 'calculated') {
+          return `~${stage}:${group}/p:${position}`
+        } else {
+          return 'real'
+        }
+      }
+      return {
+        ...m,
+        team1: strteam(m.team1),
+        team2: strteam(m.team2),
+      }
+    }))
+    : null;
+}

--- a/src/util.spec.js
+++ b/src/util.spec.js
@@ -1,3 +1,4 @@
+const { prettyPrintMatches } = require("../test/test-util");
 const { 
   calculateNextGameStartTime, 
   calculateGroupStageFixtures,
@@ -173,23 +174,3 @@ describe("Knockout stage fixtures", () => {
   })
 })
 
-
-function prettyPrintMatches(matches) {
-  return VERBOSE
-    ? console.table(matches.map(m => {
-      const strteam = t => {
-        const { type, stage, group, position } = t;
-        if (type === 'calculated') {
-          return `~${stage}:${group}/p:${position}`
-        } else {
-          return 'real'
-        }
-      }
-      return {
-        ...m,
-        team1: strteam(m.team1),
-        team2: strteam(m.team2),
-      }
-    }))
-    : null;
-}

--- a/src/validate.js
+++ b/src/validate.js
@@ -47,7 +47,14 @@ const checkPitches = (data, issues = []) => {
         }
         return true
     })
+}
 
+checkRules = (data, issues = []) => {
+    // TODO: rules must be valid
+
+    // elimination rules
+    // 1. sum of group sizes must be greater than or equal to number of teams
+    // 2. group sizes must be a power of 2
 }
 
 const checkTeams = (data, issues = []) => {

--- a/test/test-data.js
+++ b/test/test-data.js
@@ -3,6 +3,22 @@ module.exports = {
     t1: {
       tournamentId: 6,
       description: "Benelux round A",
+      rules: {
+        points: {
+          positional: [25, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 1], 
+          participation: 2, // automatically receive 2 points for participating
+        },
+        stages: {
+          preliminary: {
+            match: {
+              win: 3,
+              draw: 1,
+              loss: 0,
+            },
+          },
+          elimination: {},
+        }
+      },
       location: {
         city: "Amsterdam",
         address: "",
@@ -49,22 +65,18 @@ module.exports = {
             "Maastricht",
             "Frankfurt",
           ],
-          brackets: {
-            rules: {},
-            groups: {},
-            knockouts: {},
-          },
-          knockouts: {
-            rules: {
-              divisionOrder: ["cup", "shield", "plate"],
-              selection: "default",
-            },
-            divisions: {
-              cup: 4,
-              shield: 4,
-              plate: 5,
+          rules: {
+            preliminary: {},
+            elimination: {
+              brackets: {
+                cup: 4,
+                shield: 4,
+                plate: 8,  
+              }
             },
           },
+          groups: [],
+          fixtures: []
         },
         Ladies: {
           teams: [
@@ -78,18 +90,16 @@ module.exports = {
             "Hamb/Duss/Lux'B'",
             "Amsterdam A",
           ],
-          knockouts: [
-            {
-              division: "cup",
-              rank: 1,
-              size: 4,
+          rules: {
+            preliminary: {},
+            elimination: {
+              brackets: {
+                cup: 4,
+                shield: 8,
+              }
             },
-            {
-              division: "shield",
-              rank: 2,
-              size: 5,
-            },
-          ],
+          },
+          groups: [],
           fixtures: [],
         },
       },

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -1,0 +1,25 @@
+module.exports = {
+  prettyPrintMatches,
+}
+
+const VERBOSE = true;
+
+function prettyPrintMatches(matches) {
+  return VERBOSE
+    ? console.table(matches.map(m => {
+      const strteam = t => {
+        const { type, stage, group, position } = t;
+        if (type === 'calculated') {
+          return `~${stage}:${group}/p:${position}`
+        } else {
+          return 'real'
+        }
+      }
+      return {
+        ...m,
+        team1: strteam(m.team1),
+        team2: strteam(m.team2),
+      }
+    }))
+    : null;
+}


### PR DESCRIPTION
Changes include:

      - Added documentation
      - Solved several matching planning issues including
        - Fair resting time per team 
           - Using Berger Tables
           - and randomized team order within a group
      - Automatic fixed bracket assignment based on power-of-two group numbers
      - Fairest progression through brackets based on original seed and pairings

Checkout `docs/knockouts.md` for more info.